### PR TITLE
Integrate Turnstile Widget to Enable Button Activation Post-Verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .wrangler/
+.dev.vars

--- a/functions/generate-image.js
+++ b/functions/generate-image.js
@@ -1,4 +1,4 @@
-export async function onRequest(context) {
+export async function onRequestGet(context) {
   const { request, env } = context;
   const url = new URL(request.url);
   const prompt = url.searchParams.get("prompt") || "かわいい猫のイラスト";

--- a/functions/translate.js
+++ b/functions/translate.js
@@ -1,4 +1,4 @@
-export async function onRequest(context) {
+export async function onRequestGet(context) {
   const { request, env } = context;
   const url = new URL(request.url);
   const prompt =

--- a/index.html
+++ b/index.html
@@ -76,12 +76,17 @@
         display: none;
       }
     </style>
+    <script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=_turnstileCb"
+      defer
+    ></script>
   </head>
   <body>
+    <div id="turnstile-widget" style="padding-bottom: 20px"></div>
     <label for="prompt">どんな画像を生成しますか？詳しく教えてください</label>
     <textarea id="prompt" placeholder="例: かわいい猫のイラスト"></textarea>
     <!-- Step2: 翻訳した英語プロンプトで画像生成 -->
-    <button id="translate-btn" onclick="translateText()">
+    <button id="translate-btn" onclick="translateText()" disabled>
       <span>翻訳</span>
       <div class="spinner" id="translate-spinner"></div>
     </button>
@@ -90,7 +95,7 @@
       id="translated-prompt"
       placeholder="ここに英語の翻訳結果が表示されます"
     ></textarea>
-    <button id="generate-btn" onclick="generateImage()">
+    <button id="generate-btn" onclick="generateImage()" disabled>
       <span>画像生成</span>
       <div class="spinner" id="generate-spinner"></div>
     </button>
@@ -200,6 +205,20 @@
         } finally {
           toggleButton(generateBtn, generateSpinner, false);
         }
+      }
+      function _turnstileCb() {
+        turnstile.render("#turnstile-widget", {
+          sitekey: "0x4AAAAAAAzs018lIIK5s9-R",
+          theme: "light",
+          callback: () => {
+            translateBtn.disabled = false;
+            generateBtn.disabled = false;
+          },
+          "expired-callback": () => {
+            translateBtn.disabled = true;
+            generateBtn.disabled = true;
+          },
+        });
       }
     </script>
   </body>


### PR DESCRIPTION
This pull request introduces the integration of the Cloudflare Turnstile widget into the frontend of our application. The primary objective is to enhance security by ensuring that certain actions can only be performed after successful user verification.