### PR TITLE
Refactoring

### DIFF
--- a/functions/auth.js
+++ b/functions/auth.js
@@ -18,6 +18,13 @@ export const onRequestPost = [
       "Set-Cookie",
       await createSignedCookie({ authenticated: true }, sessionSecret)
     );
+    // JWTがレスポンスに含まれるためキャッシュさせない
+    response.headers.set(
+      "Cache-Control",
+      "no-store, no-cache, must-revalidate"
+    );
+    response.headers.set("Pragma", "no-cache");
+    response.headers.set("Expires", "0");
     return response;
   },
 ];

--- a/utils/session.js
+++ b/utils/session.js
@@ -8,7 +8,6 @@ const COOKIE_OPTIONS = {
   sameSite: "Strict",
   maxAge: 360, // Turnstileの有効期限（5分）より、少しだけ長くする（6分）
   path: "/",
-  expires: new Date(Date(Date.now() + 360 * 1000)).toUTCString(),
 };
 
 // ユーティリティ関数
@@ -25,7 +24,6 @@ export async function createSignedCookie(value, sessionSecret) {
     `Secure=${COOKIE_OPTIONS.secure ? "true" : ""}`,
     `SameSite=${COOKIE_OPTIONS.sameSite}`,
     `Max-Age=${COOKIE_OPTIONS.maxAge}`,
-    `Expires=${COOKIE_OPTIONS.expires}`,
   ]
     .filter(Boolean) // 無効なプロパティを削除
     .join("; ");


### PR DESCRIPTION
- Added "Cache-Control: no-store, no-cache, must-revalidate" to the response headers.
- Included "Pragma: no-cache" and "Expires: 0" headers for additional cache prevention.
- Ensures that responses containing JWT are not cached by browsers or intermediaries.