### PR TITLE
Add FLUX.2 klein (4B) model support

### DIFF
--- a/functions/generate-image.js
+++ b/functions/generate-image.js
@@ -13,6 +13,7 @@ async function handleGenerateImage({ request, env }) {
 
   const allowedModels = new Set([
     "@cf/black-forest-labs/flux-2-dev",
+    "@cf/black-forest-labs/flux-2-klein-4b",
     "@cf/black-forest-labs/flux-1-schnell",
   ]);
 

--- a/public/index.html
+++ b/public/index.html
@@ -52,6 +52,14 @@
           <input
             type="radio"
             name="model"
+            value="@cf/black-forest-labs/flux-2-klein-4b"
+          />
+          FLUX.2 (klein 4B)
+        </label>
+        <label class="model-option">
+          <input
+            type="radio"
+            name="model"
             value="@cf/black-forest-labs/flux-1-schnell"
           />
           FLUX.1 (schnell)


### PR DESCRIPTION
### Motivation
- Enable users to select and use the FLUX.2 klein 4B model from the UI and ensure the server accepts it as a valid model.

### Description
- Add `@cf/black-forest-labs/flux-2-klein-4b` to the `allowedModels` set in `functions/generate-image.js` so it is accepted server-side.
- Add a radio option for `@cf/black-forest-labs/flux-2-klein-4b` to the model picker in `public/index.html` so it can be selected in the UI.
- Preserve existing image generation flow so `flux-2-klein-4b` is routed through the same `runFlux2` multipart request path used by other FLUX.2 variants.

### Testing
- Launched a local static server with `python -m http.server 8000` and loaded `http://127.0.0.1:8000/public/index.html` using a Playwright script, which successfully rendered the updated UI and produced the screenshot `artifacts/flux-klein-model.png` (successful).
- No automated unit tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bfd744bac83318ae2438ea74a5d1e)